### PR TITLE
Fix for Zig 0.14

### DIFF
--- a/build.zig.zon
+++ b/build.zig.zon
@@ -1,6 +1,7 @@
 .{
-    .name = "aws-lambda",
+    .name = .aws_lambda,
     .version = "0.3.0",
+    .fingerprint = 0xdc70f8287a69c300,
 
     //.minimum_zig_version = "0.14.0",
 


### PR DESCRIPTION
Made it compile on the full Zig 0.14 release :)

See https://ziglang.org/download/0.14.0/release-notes.html#New-Package-Hash-Format